### PR TITLE
feat: スコアボードon/off設定の永続化

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,5 +70,11 @@
             <version>1.18-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.4.2</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/info/ahaha/scoreboardplugin/PlayersData.java
+++ b/src/main/java/info/ahaha/scoreboardplugin/PlayersData.java
@@ -1,0 +1,62 @@
+package info.ahaha.scoreboardplugin;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import info.ahaha.scoreboardplugin.model.PlayerData;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class PlayersData {
+    private List<PlayerData> playerDataList;
+    private final ObjectMapper mapper;
+    private final File jsonFile;
+
+    public PlayersData(File parent) {
+        playerDataList = new ArrayList<>();
+        mapper = new ObjectMapper();
+        jsonFile = new File(parent, "players.json");
+    }
+
+    public void load() {
+        try {
+            if (jsonFile.createNewFile()) {
+                save();
+            }
+            playerDataList = mapper.readValue(jsonFile, new TypeReference<List<PlayerData>>() {});
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void save() {
+        try {
+            mapper.enable(SerializationFeature.INDENT_OUTPUT);
+            mapper.writeValue(jsonFile, playerDataList);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void update(UUID uuid, boolean enableSB) {
+        playerDataList.removeIf(data -> data.getUuid().equals(uuid));
+
+        PlayerData newPlayerData = new PlayerData();
+        newPlayerData.setUuid(uuid);
+        newPlayerData.setEnableSB(enableSB);
+        playerDataList.add(newPlayerData);
+
+        CompletableFuture.runAsync(this::save);
+    }
+
+    public boolean isEnableSB(UUID uuid) {
+        Optional<PlayerData> playerData = playerDataList.stream().filter(data -> data.getUuid().equals(uuid)).findAny();
+        return !playerData.isPresent() || playerData.get().isEnableSB();
+    }
+}

--- a/src/main/java/info/ahaha/scoreboardplugin/PlayersData.java
+++ b/src/main/java/info/ahaha/scoreboardplugin/PlayersData.java
@@ -44,19 +44,19 @@ public class PlayersData {
         }
     }
 
-    public void update(UUID uuid, boolean enableSB) {
+    public void update(UUID uuid, boolean enabled) {
         playerDataList.removeIf(data -> data.getUuid().equals(uuid));
 
         PlayerData newPlayerData = new PlayerData();
         newPlayerData.setUuid(uuid);
-        newPlayerData.setEnableSB(enableSB);
+        newPlayerData.setEnabled(enabled);
         playerDataList.add(newPlayerData);
 
         CompletableFuture.runAsync(this::save);
     }
 
-    public boolean isEnableSB(UUID uuid) {
+    public boolean isEnabled(UUID uuid) {
         Optional<PlayerData> playerData = playerDataList.stream().filter(data -> data.getUuid().equals(uuid)).findAny();
-        return !playerData.isPresent() || playerData.get().isEnableSB();
+        return !playerData.isPresent() || playerData.get().isEnabled();
     }
 }

--- a/src/main/java/info/ahaha/scoreboardplugin/ScoreBoardPlugin.java
+++ b/src/main/java/info/ahaha/scoreboardplugin/ScoreBoardPlugin.java
@@ -7,8 +7,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scoreboard.*;
 
 import java.util.*;
 
@@ -31,7 +29,7 @@ public final class ScoreBoardPlugin extends JavaPlugin {
         playersData.load();
 
         for (Player player : Bukkit.getOnlinePlayers()) {
-            if (playersData.isEnableSB(player.getUniqueId())) {
+            if (playersData.isEnabled(player.getUniqueId())) {
                 new ScoreBoards(player);
             }
         }

--- a/src/main/java/info/ahaha/scoreboardplugin/ScoreBoardPlugin.java
+++ b/src/main/java/info/ahaha/scoreboardplugin/ScoreBoardPlugin.java
@@ -17,6 +17,7 @@ public final class ScoreBoardPlugin extends JavaPlugin {
     public static ScoreBoardPlugin plugin;
     public static TPSMonitor monitor;
     public static Map<UUID, ScoreBoards> boards = new HashMap<>();
+    public static PlayersData playersData;
 
     @Override
     public void onEnable() {
@@ -25,8 +26,14 @@ public final class ScoreBoardPlugin extends JavaPlugin {
         monitor = new TPSMonitor();
         monitor.start(this);
 
+        getDataFolder().mkdir();
+        playersData = new PlayersData(getDataFolder());
+        playersData.load();
+
         for (Player player : Bukkit.getOnlinePlayers()) {
-            new ScoreBoards(player);
+            if (playersData.isEnableSB(player.getUniqueId())) {
+                new ScoreBoards(player);
+            }
         }
 
         getServer().getPluginManager().registerEvents(new JoinListener(), this);

--- a/src/main/java/info/ahaha/scoreboardplugin/commands/Cmd.java
+++ b/src/main/java/info/ahaha/scoreboardplugin/commands/Cmd.java
@@ -19,8 +19,10 @@ public class Cmd implements CommandExecutor, TabCompleter {
             if (ScoreBoardPlugin.boards.containsKey(player.getUniqueId())){
                 ScoreBoardPlugin.boards.remove(player.getUniqueId());
                 player.setScoreboard(getServer().getScoreboardManager().getNewScoreboard());
+                ScoreBoardPlugin.playersData.update(player.getUniqueId(), false);
             }else {
                 ScoreBoardPlugin.boards.put(player.getUniqueId(), new ScoreBoardPlugin.ScoreBoards(player));
+                ScoreBoardPlugin.playersData.update(player.getUniqueId(), true);
             }
         }
         return true;

--- a/src/main/java/info/ahaha/scoreboardplugin/listener/JoinListener.java
+++ b/src/main/java/info/ahaha/scoreboardplugin/listener/JoinListener.java
@@ -9,7 +9,7 @@ public class JoinListener implements Listener {
 
     @EventHandler
     public void onJoin(PlayerJoinEvent e){
-        if (ScoreBoardPlugin.playersData.isEnableSB(e.getPlayer().getUniqueId())) {
+        if (ScoreBoardPlugin.playersData.isEnabled(e.getPlayer().getUniqueId())) {
             ScoreBoardPlugin.ScoreBoards scoreBoards = new ScoreBoardPlugin.ScoreBoards(e.getPlayer());
             scoreBoards.show(e.getPlayer());
         }

--- a/src/main/java/info/ahaha/scoreboardplugin/listener/JoinListener.java
+++ b/src/main/java/info/ahaha/scoreboardplugin/listener/JoinListener.java
@@ -1,7 +1,6 @@
 package info.ahaha.scoreboardplugin.listener;
 
 import info.ahaha.scoreboardplugin.ScoreBoardPlugin;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -10,7 +9,9 @@ public class JoinListener implements Listener {
 
     @EventHandler
     public void onJoin(PlayerJoinEvent e){
-        ScoreBoardPlugin.ScoreBoards scoreBoards = new ScoreBoardPlugin.ScoreBoards(e.getPlayer());
-        scoreBoards.show(e.getPlayer());
+        if (ScoreBoardPlugin.playersData.isEnableSB(e.getPlayer().getUniqueId())) {
+            ScoreBoardPlugin.ScoreBoards scoreBoards = new ScoreBoardPlugin.ScoreBoards(e.getPlayer());
+            scoreBoards.show(e.getPlayer());
+        }
     }
 }

--- a/src/main/java/info/ahaha/scoreboardplugin/model/PlayerData.java
+++ b/src/main/java/info/ahaha/scoreboardplugin/model/PlayerData.java
@@ -1,0 +1,24 @@
+package info.ahaha.scoreboardplugin.model;
+
+import java.util.UUID;
+
+public class PlayerData {
+    private UUID uuid;
+    private boolean enableSB;
+
+    public boolean isEnableSB() {
+        return enableSB;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public void setEnableSB(boolean enableSB) {
+        this.enableSB = enableSB;
+    }
+}

--- a/src/main/java/info/ahaha/scoreboardplugin/model/PlayerData.java
+++ b/src/main/java/info/ahaha/scoreboardplugin/model/PlayerData.java
@@ -4,10 +4,10 @@ import java.util.UUID;
 
 public class PlayerData {
     private UUID uuid;
-    private boolean enableSB;
+    private boolean enabled;
 
-    public boolean isEnableSB() {
-        return enableSB;
+    public boolean isEnabled() {
+        return enabled;
     }
 
     public UUID getUuid() {
@@ -18,7 +18,7 @@ public class PlayerData {
         this.uuid = uuid;
     }
 
-    public void setEnableSB(boolean enableSB) {
-        this.enableSB = enableSB;
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 }


### PR DESCRIPTION
`/sb`コマンドでスコアボードの表示をon/offしたときの設定を永続化するようにしました。
データはJSONファイルで保存し下記のようなフォーマットになります:

```json
[ {
  "uuid" : "c8c7b2e6-e583-497c-8d5b-a803e65ae081",
  "enabled" : false
}, {
  "uuid" : "00000000-0000-0000-0009-01f60232c55a",
  "enabled" : true
} ]
```